### PR TITLE
Kotlin version update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         //    add versions that occur at least twice
         versions = [
                 buildTools: "27.0.1",
-                kotlin    : "1.2.10",
+                kotlin    : "1.2.21",
                 support   : "27.0.2",
                 dagger    : "2.13",
                 retrofit  : "2.3.0",


### PR DESCRIPTION
The previous version of kotlin had a bug with `@Parcelize` annotation when ProGuard is enabled
https://youtrack.jetbrains.com/issue/KT-21628